### PR TITLE
Revert "Add photo button to markdown editor for issue comments"

### DIFF
--- a/app/src/main/java/com/thirtydegreesray/openhub/ui/fragment/MarkdownEditorFragment.java
+++ b/app/src/main/java/com/thirtydegreesray/openhub/ui/fragment/MarkdownEditorFragment.java
@@ -1,14 +1,7 @@
 package com.thirtydegreesray.openhub.ui.fragment;
 
-import android.app.Activity;
-import android.content.ClipData;
-import android.content.ClipboardManager;
-import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.PopupMenu;
 import android.text.Editable;
 import android.view.Gravity;
@@ -31,7 +24,6 @@ import java.util.ArrayList;
 import butterknife.BindView;
 import butterknife.OnClick;
 import butterknife.OnTextChanged;
-import es.dmoral.toasty.Toasty;
 
 /**
  * Created by ThirtyDegreesRay on 2017/9/29 11:52:17
@@ -45,8 +37,6 @@ public class MarkdownEditorFragment extends BaseFragment
         fragment.setArguments(BundleHelper.builder().put("text", text).put("mentionUsers", mentionUsers).build());
         return fragment;
     }
-
-    private static final int PICK_IMAGE_REQUEST_CODE = 400;
 
     @BindView(R2.id.markdown_edit) EditText markdownEdit;
     @BindView(R2.id.add_mention) ToastAbleImageButton addMention;
@@ -104,7 +94,7 @@ public class MarkdownEditorFragment extends BaseFragment
 
     @OnClick({R2.id.add_large_head, R2.id.add_medium_head, R2.id.add_small_head, R2.id.add_bold,
             R2.id.add_italic, R2.id.add_quote, R2.id.insert_code, R2.id.add_link, R2.id.add_bulleted_list,
-            R2.id.add_image, R2.id.add_mention})
+            R2.id.add_mention})
     public void onViewClicked(View view) {
         switch (view.getId()) {
             case R.id.add_large_head:
@@ -134,59 +124,11 @@ public class MarkdownEditorFragment extends BaseFragment
             case R.id.add_bulleted_list:
                 addKeyWord("-");
                 break;
-            case R.id.add_image:
-                pickImage();
-                break;
             case R.id.add_mention:
                 addKeyWord("@", 1);
                 afterTextChanged(markdownEdit.getText());
                 break;
         }
-    }
-
-    private void pickImage() {
-        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("image/*");
-        startActivityForResult(Intent.createChooser(intent, getString(R.string.add_a_photo)),
-                PICK_IMAGE_REQUEST_CODE);
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == PICK_IMAGE_REQUEST_CODE && resultCode == Activity.RESULT_OK && data != null) {
-            Uri uri = data.getData();
-            if (uri != null) {
-                onImagePicked(uri);
-            } else {
-                Toasty.error(getActivity(), getString(R.string.failed_to_recognize)).show();
-            }
-        }
-    }
-
-    private void onImagePicked(Uri uri) {
-        String uriString = uri.toString();
-        if (StringUtils.isBlank(uriString)) {
-            Toasty.error(getActivity(), getString(R.string.failed_to_recognize)).show();
-            return;
-        }
-
-        new AlertDialog.Builder(getActivity())
-                .setTitle(getString(R.string.add_a_photo))
-                .setMessage(getString(R.string.image_upload_tip))
-                .setPositiveButton(getString(R.string.copy_url), (dialog, which) -> {
-                    ClipboardManager cm = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
-                    if (cm != null) {
-                        cm.setPrimaryClip(ClipData.newPlainText("imageUri", uriString));
-                        Toasty.success(getActivity(), getString(R.string.success_copied)).show();
-                    }
-                })
-                .setNeutralButton(getString(R.string.insert_link), (dialog, which) -> {
-                    addKeyWord("![](" + uriString + ")", 4, false);
-                })
-                .setNegativeButton(getString(R.string.cancel), null)
-                .show();
     }
 
     private void addKeyWord(String keyWord){

--- a/app/src/main/res/layout/fragment_markdown_editor.xml
+++ b/app/src/main/res/layout/fragment_markdown_editor.xml
@@ -104,16 +104,6 @@
             app:toast_text="@string/add_a_bulleted_list"/>
 
         <com.thirtydegreesray.openhub.ui.widget.ToastAbleImageButton
-            android:id="@+id/add_image"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:src="@drawable/ic_image"
-            android:scaleType="center"
-            android:background="?android:selectableItemBackgroundBorderless"
-            app:toast_text="@string/add_a_photo"/>
-
-        <com.thirtydegreesray.openhub.ui.widget.ToastAbleImageButton
             android:id="@+id/add_mention"
             android:layout_width="0dp"
             android:layout_height="match_parent"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -272,15 +272,6 @@
     <string name="insert_code">Code einfügen</string>
     <string name="insert_a_quote">Fügen Sie ein Angebot ein</string>
     <string name="add_a_bulleted_list">Fügen Sie eine Aufzählungsliste hinzu</string>
-    <string name="add_a_photo">Foto hinzufügen</string>
-    <string name="image_upload_tip">GitHub unterstützt das direkte Hochladen von Bildern für Issue-Kommentare über die API nicht.
-
-Bitte laden Sie das Bild (z.B. im Browser auf GitHub oder bei einem anderen Host) hoch und fügen Sie die Bild-URL per Markdown in den Kommentar ein:
-
-![](https://...)
-
-Wir haben die ausgewählte Bild-URI zur Vereinfachung auch in die Zwischenablage kopiert.</string>
-    <string name="insert_link">Einfügen</string>
     <string name="mention">Erwähnen Sie direkt einen Nutzer oder ein Team</string>
     <string name="nothing_to_preview">Nichts zu sehen</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -278,16 +278,7 @@
     <string name="insert_code">Insert code</string>
     <string name="insert_a_quote">Insert a quote</string>
     <string name="add_a_bulleted_list">Add a bulleted list</string>
-    <string name="add_a_photo">Add a photo</string>
-    <string name="image_upload_tip">GitHub doesn’t support uploading images directly via the API for issue comments.
-
-Please upload the image (e.g. in a browser on GitHub, or another host) and paste the image URL into the comment using markdown:
-
-![](https://...)
-
-We also copied the selected image URI to clipboard for convenience.</string>
     <string name="mention">Directly mention a user or team</string>
-    <string name="insert_link">Insert</string>
     <string name="nothing_to_preview">Nothing to preview</string>
 
     <string name="title">Title</string>


### PR DESCRIPTION
Reverts Sergey842248/OpenHub#68 because API doesn't allow photo uploads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed image attachment functionality from the markdown editor, including the image upload button from the toolbar
  * Removed associated UI strings and instructions related to image operations from application localizations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->